### PR TITLE
Added support for search keyboard shortcut

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,6 +14,6 @@ var elixir = require('laravel-elixir');
 elixir(function(mix) {
     mix.sass('laravel.scss', 'public/assets/css');
     mix.scripts(['jquery.js', 'plugins/prism.js', 'plugins/bootstrap.js', 'plugins/scotchPanels.js', 'laravel.js'],
-    	'resources/assets/js/',
-    	'public/assets/js/laravel.js');
+        'public/assets/js/laravel.js', 
+        'resources/assets/js/');
 });

--- a/public/assets/js/laravel.js
+++ b/public/assets/js/laravel.js
@@ -964,8 +964,20 @@ $(function() {
 
   // gheading links
   $('.docs-wrapper').find('a[name]').each(function () {
-        var anchor = $('<a href="#' + this.name + '">');
-        $(this).parent().next('h2').wrapInner(anchor);
-    })
+      var anchor = $('<a href="#' + this.name + '">');
+      $(this).parent().next('h2').wrapInner(anchor);
+  });
+
+  // Selects the search area when pressing /
+  $(document).on("keypress", function (e) {
+    // We don't want to select the search box if we are in an input
+    if ($(e.target).closest("input")[0]) {
+        return;
+    }
+    if (e.which === 47) {
+      $('.searchbox').select();
+      e.preventDefault();
+    }
+  });
 
 });

--- a/resources/assets/js/laravel.js
+++ b/resources/assets/js/laravel.js
@@ -41,8 +41,20 @@ $(function() {
 
   // gheading links
   $('.docs-wrapper').find('a[name]').each(function () {
-        var anchor = $('<a href="#' + this.name + '">');
-        $(this).parent().next('h2').wrapInner(anchor);
-    })
+      var anchor = $('<a href="#' + this.name + '">');
+      $(this).parent().next('h2').wrapInner(anchor);
+  });
+
+  // Selects the search area when pressing /
+  $(document).on("keypress", function (e) {
+    // We don't want to select the search box if we are in an input
+    if ($(e.target).closest("input")[0]) {
+        return;
+    }
+    if (e.which === 47) {
+      $('.searchbox').select();
+      e.preventDefault();
+    }
+  });
 
 });

--- a/resources/views/partials/search-form.blade.php
+++ b/resources/views/partials/search-form.blade.php
@@ -1,3 +1,3 @@
 <form action="/docs/{{ $currentVersion }}/search">
-    <input type="search" name="keyword" placeholder="Search" value="{{ $keyword or '' }}">
+    <input type="search" name="keyword" placeholder="Search" value="{{ $keyword or '' }}" class="searchbox">
 </form>


### PR DESCRIPTION
Love what you're doing with ES on the docs. Thought I'd add in a keyboard shortcut to jump to the search box for power users!

Just hit / when on the page and you'll be taken to the selected search text for your next query
